### PR TITLE
upgrade enum package to v2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,35 +63,18 @@ $model->status = StatusEnum::PUBLISHED();
 $model->status->isEqual(StatusEnum::ARCHIVED());
 ``` 
 
-In some cases, enums can be stored differently in the database. 
-Take for example a legacy application.
+In some cases, enums should be stored as integer (index) in the database.
 
-By using the `HasEnums` trait, you can provide a mapping on your enum classes:
-
-```php
-/**
- * @method static self DRAFT()
- * @method static self PUBLISHED()
- * @method static self ARCHIVED()
- */
-final class StatusEnum extends Enum
-{
-    public static $map = [
-        'archived' => 'legacy archived value',
-    ];
-}
-```
-
-Once a mapping is provided and the trait is used in your model, 
-the package will automatically handle it for you.
+By using the `$casts` property you can cast your `status` attribute to `int` or `integer` and the trait will store the index instead of the value.
 
 ### Roadmap
 
 - [ ] Models fields
     - [x] Automatic value casting [#1](https://github.com/spatie/laravel-enum/pull/1)
-    - [ ] Mapping support [spatie/enum#25](https://github.com/spatie/enum/pull/25)
+    - [x] Mapping support [spatie/enum#25](https://github.com/spatie/enum/pull/25)
 - [ ] Model scopes [#4](https://github.com/spatie/laravel-enum/pull/4)
 - [ ] Validation [#5](https://github.com/spatie/laravel-enum/issues/5)
+- [ ] Request Transformation [#7](https://github.com/spatie/laravel-enum/pull/7)
 
 ### Testing
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "spatie/enum": "^2.0"
+        "spatie/enum": "^2.1"
     },
     "require-dev": {
         "larapack/dd": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,12 @@
             "email": "brent@spatie.be",
             "homepage": "https://spatie.be",
             "role": "Developer"
+        },
+        {
+            "name": "Tom Witkowski",
+            "email": "dev.gummibeer@gmail.com",
+            "homepage": "https://gummibeer.de",
+            "role": "Developer"
         }
     ],
     "require": {

--- a/src/HasEnums.php
+++ b/src/HasEnums.php
@@ -72,8 +72,9 @@ trait HasEnums
     {
         $enumClass = $this->enums[$key];
         $enumInterface = Enumerable::class;
+        $classImplementsEnumerable = class_implements($enumClass)[$enumInterface] ?? false;
 
-        if (! isset(class_implements($enumClass)[$enumInterface])) {
+        if (! $classImplementsEnumerable) {
             throw new InvalidArgumentException("Expected {$enumClass} to implement {$enumInterface}");
         }
 

--- a/src/HasEnums.php
+++ b/src/HasEnums.php
@@ -78,9 +78,9 @@ trait HasEnums
      */
     protected function asEnum(string $class, $value): Enumerable
     {
-        return forward_static_call_array(
+        return forward_static_call(
             $class.'::make',
-            [$value]
+            $value
         );
     }
 }

--- a/tests/Extra/Post.php
+++ b/tests/Extra/Post.php
@@ -17,6 +17,8 @@ class Post extends Model
 {
     use HasEnums;
 
+    protected $table = 'posts';
+
     protected $guarded = [];
 
     protected $enums = [

--- a/tests/Extra/Post.php
+++ b/tests/Extra/Post.php
@@ -9,6 +9,7 @@ use Spatie\Enum\Laravel\HasEnums;
 
 /**
  * @property \Spatie\Enum\Laravel\Tests\Extra\StatusEnum status
+ * @property mixed invalid_enum
  *
  * @method static self create(array $properties)
  */
@@ -20,6 +21,7 @@ class Post extends Model
 
     protected $enums = [
         'status' => StatusEnum::class,
+        'invalid_enum' => Post::class,
     ];
 
     public static function migrate()

--- a/tests/Extra/StatusEnum.php
+++ b/tests/Extra/StatusEnum.php
@@ -11,7 +11,7 @@ use Spatie\Enum\Enum;
  */
 final class StatusEnum extends Enum
 {
-    public static $map = [
+    const MAP_VALUE = [
         'archived' => 'stored archive',
     ];
 }

--- a/tests/HasEnumsCastTest.php
+++ b/tests/HasEnumsCastTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Enum\Laravel\Tests;
 
+use InvalidArgumentException;
+use Spatie\Enum\Enumerable;
 use Spatie\Enum\Laravel\Exceptions\InvalidEnumError;
 use Spatie\Enum\Laravel\Tests\Extra\Post;
 use Spatie\Enum\Laravel\Tests\Extra\StatusEnum;
@@ -39,7 +41,7 @@ final class HasEnumsCastTest extends TestCase
         ]);
 
         $this->assertEquals(
-            StatusEnum::$map['archived'],
+            StatusEnum::MAP_VALUE['archived'],
             $model->getAttributes()['status']
         );
 
@@ -101,5 +103,15 @@ final class HasEnumsCastTest extends TestCase
         ]);
 
         $this->assertTrue($post->status->isEqual(StatusEnum::draft()));
+    }
+
+    /** @test */
+    public function throws_exception_if_enum_class_is_not_enumerable()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected '.Post::class.' to implement '.Enumerable::class);
+
+        $post = new Post();
+        $post->invalid_enum = 'unknown';
     }
 }

--- a/tests/HasEnumsCastTest.php
+++ b/tests/HasEnumsCastTest.php
@@ -21,6 +21,25 @@ final class HasEnumsCastTest extends TestCase
         $model->refresh();
 
         $this->assertTrue($model->status->isEqual(StatusEnum::draft()));
+        $this->assertEquals('draft', $model->getOriginal('status'));
+    }
+
+    /** @test */
+    public function it_saves_the_index_of_an_enum()
+    {
+        $model = new class extends Post {
+            protected $casts = [
+                'status' => 'int',
+            ];
+        };
+
+        $model->status = StatusEnum::draft();
+        $model->save();
+
+        $model->refresh();
+
+        $this->assertTrue($model->status->isEqual(StatusEnum::draft()));
+        $this->assertEquals(0, $model->getOriginal('status'));
     }
 
     /** @test */


### PR DESCRIPTION
implement https://github.com/spatie/enum/pull/25

I've also added the ability to cast an attribute to `int` or `integer` and in this case the enum will set the index as attribute value.

This allows to use it, without changes, for both cases.

```php
protected $casts = [
    'status' => 'int',
];
```