### PR TITLE
Remove Laravel provider/facade from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,15 +41,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Spatie\\Skeleton\\SkeletonServiceProvider"
-            ],
-            "aliases": {
-                "Skeleton": "Spatie\\Skeleton\\SkeletonFacade"
-            }
-        }
     }
 }


### PR DESCRIPTION
Currently, installing this package via composer fails as this package does not have `Spatie\Skeleton\SkeletonServiceProvider` nor `Spatie\Skeleton\SkeletonFacade`.