### PR TITLE
[PHP7.4] require symfony/console with PHP7.4 compatible version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "php": "^7.2",
         "illuminate/console": "^5.8 || ^6.0",
         "illuminate/support": "^5.8 || ^6.0",
-        "spatie/enum": "^2.1"
+        "spatie/enum": "^2.1",
+        "symfony/console": "^4.3.4"
     },
     "conflict": {
         "bensampo/laravel-enum": "*"


### PR DESCRIPTION
fixes #21 

> PHP 7.4 will be released on November 28, 2019.