### PR TITLE
Fixed validation error...I believe...

### DIFF
--- a/src/Rules/EnumRule.php
+++ b/src/Rules/EnumRule.php
@@ -2,13 +2,12 @@
 
 namespace Spatie\Enum\Laravel\Rules;
 
-use Error;
-use Exception;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 use Spatie\Enum\Enum;
+use Throwable;
 
 class EnumRule implements Rule
 {
@@ -34,7 +33,7 @@ class EnumRule implements Rule
             $this->asEnum($value);
 
             return true;
-        } catch (Error | Exception $ex) {
+        } catch (Throwable $ex) {
             return false;
         }
     }

--- a/src/Rules/EnumRule.php
+++ b/src/Rules/EnumRule.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Enum\Laravel\Rules;
 
+use Error;
 use Exception;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Arr;
@@ -33,7 +34,7 @@ class EnumRule implements Rule
             $this->asEnum($value);
 
             return true;
-        } catch (Exception $ex) {
+        } catch (Error | Exception $ex) {
             return false;
         }
     }

--- a/tests/Rules/EnumRuleTest.php
+++ b/tests/Rules/EnumRuleTest.php
@@ -28,6 +28,30 @@ final class EnumRuleTest extends TestCase
         $this->assertFalse($rule->passes('attribute', 'stored draft'));
     }
 
+    /**
+     * @test
+     * @dataProvider provideInvalidTypes
+     */
+    public function it_will_not_validate_nor_throw_when_given_an_invalid_type($invalidType)
+    {
+        $rule = new EnumRule(StatusEnum::class);
+
+        $this->assertFalse($rule->passes('attribute', $invalidType));
+    }
+
+    public function provideInvalidTypes()
+    {
+        return [
+            [null],
+            [[]],
+            [['an', 'array', 'of', 'strings']],
+            [true],
+            [false],
+            [12.34],
+            [new \stdClass],
+        ];
+    }
+
     /** @test */
     public function it_returns_default_validation_message()
     {


### PR DESCRIPTION
I can write a test for this, but the basic issue is that when using `EnumRule` to validate, it calls `asEnum`, which attempts to create a new enum with the given input.  If this fails an exception is thrown...**or an instance of `TypeError`**.

It's the latter scenario that I found to be causing a problem.  I've simply added `Error` to the `catch` clause, which fixes it in my own tests.

Please let me know if you have any questions or concerns.

PS I know this is Hacktoberfest time and there are complaints about people spamming for t-shirts.  I'm a fan of Hacktoberfest and love the t-shirts, but this isn't spam.  I legit ran into the problem today and the fix **appears to be** quite simple.  Please give me the benefit of the doubt and let me know if you're otherwise worried.  Thx. 🤓