### PR TITLE
Adds an example Enum class to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ $model->status = StatusEnum::DRAFT();
 $model->status->equals(StatusEnum::DRAFT());
 ```
 
+#### Example Enum Class
+```php
+namespace App\Enums;
+
+use Spatie\Enum\Laravel\Enum;
+
+/**
+ * @method static self DRAFT()
+ * @method static self PREVIEW()
+ * @method static self PUBLISHED()
+ * @method static self ARCHIVED()
+ */
+final class StatusEnum extends Enum
+{
+}
+```
+
+More information on working with the Enum class can be found in the [documentation of spatie/enum](https://spatie.be/docs/enum/v3/introduction).
+
 ### Validation Rule
 
 This package provides a validation rule to validate your request data against a given enumerable.


### PR DESCRIPTION
As it wasn't very/directly apparent from the readme to extend from the actual Enum class made for Laravel [imho];
this PR adds an example Enum class based on the existing `StatusEnum` example being used, and a link to the documentation of spatie/enum.

@Gummibeer - I'm not that familiar with putting this all in the correct wording... _guide me senpai_ 😁 

closes #53