### PR TITLE
Implicit & Explicit Route Bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,43 @@ new TransformEnums([
 ]);
 ```
 
+### Route Binding
+
+Beside using form requests, you can also use route binding. Similar [Laravel's Route Model Binding](https://laravel.com/docs/routing#route-model-binding), it automatically inject enum instances into your route action.
+
+#### Implicit Binding
+
+To use implicit route binding, be sure add `Spatie\Enum\Laravel\Http\Middleware\SubstituteBindings` middleware. For example, add it in your `app\Http\Kernel.php`:
+```php
+// app/Http/Kernel.php
+
+protected $middlewareGroups = [
+    'web' => [
+        // ...
+        \Spatie\Enum\Laravel\Http\Middleware\SubstituteBindings::class,
+    ],
+];
+```
+
+Use a type-hinted variable name that matches route segment to use implicit route binding.
+
+```php
+Route::get('/posts/{status}', function (StatusEnum $status) {
+    return $status;
+});
+```
+
+#### Explicit Binding
+
+To have an explicit binding, there is a `Route::enum()` macro:
+
+```php
+Route::enum('status', StatusEnum::class);
+Route::get('/posts/{status}', function (Request $request) {
+    return $request->route('status');
+});
+```
+
 ### Enum Make Command
 
 We provide an artisan make command which allows you to quickly create new enumerables.

--- a/src/Exceptions/InvalidEnumValueException.php
+++ b/src/Exceptions/InvalidEnumValueException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\Enum\Laravel\Exceptions;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class InvalidEnumValueException extends NotFoundHttpException
+{
+}

--- a/src/Http/Middleware/SubstituteBindings.php
+++ b/src/Http/Middleware/SubstituteBindings.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\Enum\Laravel\Http\Middleware;
+
+use Closure;
+use Illuminate\Container\Container;
+use Spatie\Enum\Laravel\Routing\ImplicitRouteBinding;
+
+class SubstituteBindings
+{
+    /**
+     * The container instance.
+     *
+     * @var \Illuminate\Container\Container
+     */
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        ImplicitRouteBinding::resolveForRoute($this->container, $request->route());
+
+        return $next($request);
+    }
+}

--- a/src/Routing/ImplicitRouteBinding.php
+++ b/src/Routing/ImplicitRouteBinding.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Spatie\Enum\Laravel\Routing;
+
+use BadMethodCallException;
+use Illuminate\Container\Container;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Reflector;
+use Illuminate\Support\Str;
+use Spatie\Enum\Enum;
+use Spatie\Enum\Laravel\Exceptions\InvalidEnumValueException;
+
+class ImplicitRouteBinding
+{
+    public static function resolveForRoute(Container $container, Route $route): void
+    {
+        $parameters = $route->parameters();
+
+        foreach ($route->signatureParameters(Enum::class) as $parameter) {
+            if (! $parameterName = static::getParameterName($parameter->getName(), $parameters)) {
+                continue;
+            }
+
+            $parameterValue = $parameters[$parameterName];
+
+            if ($parameterValue instanceof Enum) {
+                continue;
+            }
+
+            try {
+                $instance = $container->make(Reflector::getParameterClassName($parameter), ['value' => $parameterValue]);
+            } catch (BadMethodCallException $e) {
+                throw new InvalidEnumValueException($e->getMessage(), $e);
+            }
+
+            $route->setParameter($parameterName, $instance);
+        }
+    }
+
+    protected static function getParameterName(string $name, array $parameters): ?string
+    {
+        if (array_key_exists($name, $parameters)) {
+            return $name;
+        }
+
+        if (array_key_exists($snakedName = Str::snake($name), $parameters)) {
+            return $snakedName;
+        }
+    }
+}

--- a/tests/FeatureExplicitRouteBindingTest.php
+++ b/tests/FeatureExplicitRouteBindingTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\Enum\Laravel\Tests;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Routing\Registrar;
+use Illuminate\Events\Dispatcher;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Router;
+use Spatie\Enum\Laravel\Tests\Extra\StatusEnum;
+
+class FeatureExplicitRouteBindingTest extends TestCase
+{
+    /** @test */
+    public function it_resolves_binding()
+    {
+        $router = $this->createRouter();
+
+        $router->get('test/{status}', [
+            'middleware' => SubstituteBindings::class,
+            'uses' => function ($status) {
+                return $status->toJson();
+            },
+        ]);
+        $router->enum('status', StatusEnum::class);
+
+        $request = Request::create('test/draft');
+        $result = $router->dispatch($request)->getContent();
+
+        $this->assertEquals($result, StatusEnum::draft()->toJson());
+    }
+
+    protected function createRouter()
+    {
+        $container = new Container();
+
+        $router = new Router(new Dispatcher, $container);
+        $container->singleton(Registrar::class, fn () => $router);
+
+        return $router;
+    }
+}

--- a/tests/Routing/ImplicitRouteBindingTest.php
+++ b/tests/Routing/ImplicitRouteBindingTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\Enum\Laravel\Tests\Routing;
+
+use Illuminate\Container\Container;
+use Illuminate\Routing\Route;
+use Spatie\Enum\Laravel\Routing\ImplicitRouteBinding;
+use Spatie\Enum\Laravel\Tests\Extra\StatusEnum;
+use Spatie\Enum\Laravel\Tests\TestCase;
+
+class ImplicitRouteBindingTest extends TestCase
+{
+    /** @test */
+    public function it_can_resolve_the_implicit_route_transformations_for_the_given_route()
+    {
+        $action = ['uses' => function (StatusEnum $status) {
+            return $status;
+        }];
+
+        $route = new Route('GET', '/test', $action);
+        $route->parameters = ['status' => StatusEnum::draft()->value];
+        $route->prepareForSerialization();
+
+        $container = Container::getInstance();
+
+        ImplicitRouteBinding::resolveForRoute($container, $route);
+
+        $this->assertTrue(StatusEnum::draft()->equals($route->parameter('status')));
+    }
+}


### PR DESCRIPTION
### Problems with TransformEnums

First, I know there is already a [TransformEnums](https://github.com/spatie/laravel-enum/blob/5daf8a5fd97212c51deb63bdf7b88af512baade8/src/Http/Middleware/TransformEnums.php) middleware available.
The original PR (#7) gives following route example:

```php
Route::get('post/{status}', 'xyz@abc')
    ->middleware(new TransformEnums([ 'status' => StatusEnum::class ]));
```

This example doesn't work, because inside Laravel, MiddlewareNameResolver only accept either a string or a Closure. In this example, it's a Middleware instance. (see [source code](https://github.com/laravel/framework/blob/4ad4f199f77392e176f0ee56371e116b057270cd/src/Illuminate/Routing/MiddlewareNameResolver.php#L17-L43))
If it accept Closure, then we got a workaround:

```php
Route::get('post/{status}', 'xyz@abc')
    ->middleware(static fn ($request, $next) => (new TransformEnums([ 'status' => StatusEnum::class ]))->handle($request, $next));
```

There comes another problem in this middleware approach, that we can't type hinting on the method signature, because service container will try to resolve it.

```php
// Illuminate\Contracts\Container\BindingResolutionException
//   Unresolvable dependency resolving [Parameter #0 [ <required> $value ]] in class Spatie\Enum\Enum
Route::get('post/{status}', fn (StatusEnum $status) => var_dump($status))
    ->middleware(static fn ($request, $next) => (new TransformEnums([ 'status' => StatusEnum::class ]))->handle($request, $next));
```

It would be awesome if we can just type hinting on controller method and get it automatically convert to a `Spatie\Enum\Enum` instance.


### ImplicitRouteBinding

Laravel already does a similar thing to Models, which is so called implicit route binding. Under the hood, implicit route binding looks for type hinting. If the parameter type is a sub class of [UrlRoutable](https://github.com/laravel/framework/blob/cc03df353661a4b7364a5a0c11fa858c7d33c5c3/src/Illuminate/Contracts/Routing/UrlRoutable.php), it calls `resolveRouteBinding` on it to get a model instance.
The first thought I got is to make `Enum` implements `UrlRoutable`, it works but also breaks some thing.
If you look at `Illuminate/Routing/ImplicitRouteBinding`, it will first call service container to make an instance of the model, then call the `resolveRouteBiding` on the created model instance. If we want to make `Enum` use the same `UrlRoutable`, then it must be instancable without given a value.

Here I got another idea, is to make our own middleware use the similar way to resolve `Enum` instances, but instead looking for `UrlRoutable`, we just looking for `Enum`. This PR is a PoC.

### Example usage

```php
// app/Http/Kernel.php

protected $middlewareGroups = [
  'web' => [
    // ...
    \Spatie\Enum\Laravel\Http\Middleware\SubstituteBindings::class,
  ],
]
```


```php
// routes/web.php

Route::get('post/{status}', fn (StatusEnum $status) => var_export($status) );
```

### Todo

- [x] Tests
- [ ] Better naming on classes, methods.
- [x] Documentation.
- [x] Explicit bindings.