### PR TITLE
feat: also accept initialized class in validation

### DIFF
--- a/src/Rules/EnumRule.php
+++ b/src/Rules/EnumRule.php
@@ -29,6 +29,10 @@ class EnumRule implements Rule
         $this->attribute = $attribute;
         $this->value = $value;
 
+        if ($value instanceof $this->enum) {
+            return true;
+        }
+
         try {
             $this->asEnum($value);
 

--- a/tests/Rules/EnumRuleTest.php
+++ b/tests/Rules/EnumRuleTest.php
@@ -28,6 +28,12 @@ final class EnumRuleTest extends TestCase
         $this->assertFalse($rule->passes('attribute', 'stored draft'));
     }
 
+    public function it_will_validate_a_class()
+    {
+        $rule = new EnumRule(StatusEnum::class);
+        $this->assertTrue($rule->passes('attribute', StatusEnum::draft()));
+    }
+
     /**
      * @test
      * @dataProvider provideInvalidTypes


### PR DESCRIPTION
This is a fix for issue #63 where Livewire passes a class to the validation instead of a name or value. Let me know if any corrections are necessary.