### PR TITLE
Add toRule method to Enum base class

### DIFF
--- a/src/Enum.php
+++ b/src/Enum.php
@@ -21,7 +21,7 @@ abstract class Enum extends BaseEnum implements Jsonable, Castable
         return new EnumCast(static::class, ...$arguments);
     }
 
-    public static function rule(): EnumRule
+    public static function toRule(): EnumRule
     {
         return new EnumRule(static::class);
     }

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Support\Jsonable;
 use Spatie\Enum\Enum as BaseEnum;
 use Spatie\Enum\Laravel\Casts\EnumCast;
 use Spatie\Enum\Laravel\Casts\EnumCollectionCast;
+use Spatie\Enum\Laravel\Rules\EnumRule;
 
 abstract class Enum extends BaseEnum implements Jsonable, Castable
 {
@@ -18,6 +19,11 @@ abstract class Enum extends BaseEnum implements Jsonable, Castable
         }
 
         return new EnumCast(static::class, ...$arguments);
+    }
+
+    public static function rule(): EnumRule
+    {
+        return new EnumRule(static::class);
     }
 
     public function toJson($options = 0): string


### PR DESCRIPTION
This PR will make setting enum rules cleaner.

It allows to do the following:
```php
$rules = [
    'status' => StatusEnum::rule(),
];
```

instead of doing this
```php
$rules = [
    'status' => new EnumRule(StatusEnum::class),
];
```