### PR TITLE
Fixed attempt to save an empty array and it saves empty string instead of null

### DIFF
--- a/src/Casts/EnumCollectionCast.php
+++ b/src/Casts/EnumCollectionCast.php
@@ -50,7 +50,7 @@ class EnumCollectionCast extends Cast
      */
     public function set($model, string $key, $value, array $attributes)
     {
-        if (is_null($value) || empty($value)) {
+        if (is_null($value)) {
             return $this->handleNullValue($model, $key);
         }
 
@@ -92,6 +92,9 @@ class EnumCollectionCast extends Cast
     protected function fromDatabase(string $value): array
     {
         if ($this->format === self::FORMAT_COMMA) {
+            if (empty($value))
+                return [];
+
             return array_map('trim', explode(',', $value));
         }
 

--- a/src/Casts/EnumCollectionCast.php
+++ b/src/Casts/EnumCollectionCast.php
@@ -50,7 +50,7 @@ class EnumCollectionCast extends Cast
      */
     public function set($model, string $key, $value, array $attributes)
     {
-        if (is_null($value)) {
+        if (is_null($value) || empty($value)) {
             return $this->handleNullValue($model, $key);
         }
 

--- a/src/Casts/EnumCollectionCast.php
+++ b/src/Casts/EnumCollectionCast.php
@@ -2,7 +2,12 @@
 
 namespace Spatie\Enum\Laravel\Casts;
 
+use BadMethodCallException;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Spatie\Enum\Enum;
+use Spatie\Enum\Laravel\Exceptions\NotNullableEnumField;
+use TypeError;
 
 class EnumCollectionCast extends Cast
 {
@@ -21,15 +26,15 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param Model $model
      * @param string $key
      * @param string|null|mixed $value
      * @param array $attributes
      *
-     * @return \Spatie\Enum\Enum[]|null
+     * @return Enum[]|null
      *
-     * @throws \BadMethodCallException
-     * @throws \Spatie\Enum\Laravel\Exceptions\NotNullableEnumField
+     * @throws BadMethodCallException
+     * @throws NotNullableEnumField
      */
     public function get($model, string $key, $value, array $attributes)
     {
@@ -41,9 +46,9 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param \Illuminate\Database\Eloquent\Model $model
+     * @param Model $model
      * @param string $key
-     * @param int[]|string[]|\Spatie\Enum\Enum[]|null|mixed $value
+     * @param int[]|string[]|Enum[]|null|mixed $value
      * @param array $attributes
      *
      * @return string|null
@@ -58,12 +63,12 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param int[]|string[]|\Spatie\Enum\Enum[] $values
+     * @param int[]|string[]|Enum[] $values
      *
-     * @return \Spatie\Enum\Enum[]
+     * @return Enum[]
      *
-     * @throws \TypeError
-     * @throws \BadMethodCallException
+     * @throws TypeError
+     * @throws BadMethodCallException
      */
     protected function asEnums(array $values): array
     {
@@ -71,7 +76,7 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param \Spatie\Enum\Enum[] $enums
+     * @param Enum[] $enums
      *
      * @return string
      */
@@ -92,8 +97,9 @@ class EnumCollectionCast extends Cast
     protected function fromDatabase(string $value): array
     {
         if ($this->format === self::FORMAT_COMMA) {
-            if (empty($value))
+            if (empty($value)) {
                 return [];
+            }
 
             return array_map('trim', explode(',', $value));
         }

--- a/src/Casts/EnumCollectionCast.php
+++ b/src/Casts/EnumCollectionCast.php
@@ -2,12 +2,7 @@
 
 namespace Spatie\Enum\Laravel\Casts;
 
-use BadMethodCallException;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
-use Spatie\Enum\Enum;
-use Spatie\Enum\Laravel\Exceptions\NotNullableEnumField;
-use TypeError;
 
 class EnumCollectionCast extends Cast
 {
@@ -26,15 +21,15 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param Model $model
+     * @param \Illuminate\Database\Eloquent\Model $model
      * @param string $key
      * @param string|null|mixed $value
      * @param array $attributes
      *
-     * @return Enum[]|null
+     * @return \Spatie\Enum\Enum[]|null
      *
-     * @throws BadMethodCallException
-     * @throws NotNullableEnumField
+     * @throws \BadMethodCallException
+     * @throws \Spatie\Enum\Laravel\Exceptions\NotNullableEnumField
      */
     public function get($model, string $key, $value, array $attributes)
     {
@@ -46,9 +41,9 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param Model $model
+     * @param \Illuminate\Database\Eloquent\Model $model
      * @param string $key
-     * @param int[]|string[]|Enum[]|null|mixed $value
+     * @param int[]|string[]|\Spatie\Enum\Enum[]|null|mixed $value
      * @param array $attributes
      *
      * @return string|null
@@ -63,12 +58,12 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param int[]|string[]|Enum[] $values
+     * @param int[]|string[]|\Spatie\Enum\Enum[] $values
      *
-     * @return Enum[]
+     * @return \Spatie\Enum\Enum[]
      *
-     * @throws TypeError
-     * @throws BadMethodCallException
+     * @throws \TypeError
+     * @throws \BadMethodCallException
      */
     protected function asEnums(array $values): array
     {
@@ -76,7 +71,7 @@ class EnumCollectionCast extends Cast
     }
 
     /**
-     * @param Enum[] $enums
+     * @param \Spatie\Enum\Enum[] $enums
      *
      * @return string
      */

--- a/tests/FeatureModelCastTest.php
+++ b/tests/FeatureModelCastTest.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\Enum\Laravel\Tests;
 
-use Spatie\Enum\Laravel\Exceptions\NotNullableEnumField;
 use Spatie\Enum\Laravel\Tests\Extra\Post;
 use Spatie\Enum\Laravel\Tests\Extra\StatusEnum;
 use stdClass;

--- a/tests/FeatureModelCastTest.php
+++ b/tests/FeatureModelCastTest.php
@@ -124,19 +124,8 @@ final class FeatureModelCastTest extends TestCase
 
         $this->assertTrue($model->status->equals(StatusEnum::draft()));
         $this->assertEquals('draft', $model->getOriginal('status'));
-        $this->assertNull($model->nullable_set_of_enums);
-    }
-
-    /** @test */
-    public function it_tries_to_save_an_empty_array_for_not_nullable_set_of_enums()
-    {
-        $this->expectException(NotNullableEnumField::class);
-
-        $model = Post::create([
-            'set_of_enums' => [],
-        ]);
-
-        $model->refresh();
+        $this->assertIsArray($model->nullable_set_of_enums);
+        $this->assertEmpty($model->nullable_set_of_enums);
     }
 
     /** @test */

--- a/tests/FeatureModelCastTest.php
+++ b/tests/FeatureModelCastTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\Enum\Laravel\Tests;
 
+use Spatie\Enum\Laravel\Exceptions\NotNullableEnumField;
 use Spatie\Enum\Laravel\Tests\Extra\Post;
 use Spatie\Enum\Laravel\Tests\Extra\StatusEnum;
 use stdClass;
@@ -109,6 +110,33 @@ final class FeatureModelCastTest extends TestCase
         $this->assertTrue($model->status->equals(StatusEnum::draft()));
         $this->assertEquals('draft', $model->getOriginal('status'));
         $this->assertNull($model->nullable_set_of_enums);
+    }
+
+    /** @test */
+    public function it_saves_an_empty_array_for_nullable_set_of_enums()
+    {
+        $model = Post::create([
+            'status' => StatusEnum::draft(),
+            'nullable_set_of_enums' => [],
+        ]);
+
+        $model->refresh();
+
+        $this->assertTrue($model->status->equals(StatusEnum::draft()));
+        $this->assertEquals('draft', $model->getOriginal('status'));
+        $this->assertNull($model->nullable_set_of_enums);
+    }
+
+    /** @test */
+    public function it_tries_to_save_an_empty_array_for_not_nullable_set_of_enums()
+    {
+        $this->expectException(NotNullableEnumField::class);
+
+        $model = Post::create([
+            'set_of_enums' => [],
+        ]);
+
+        $model->refresh();
     }
 
     /** @test */


### PR DESCRIPTION
Hey, @Gummibeer I found an issue in my own contribution I pushed a few weeks ago. I find that if you try to save an empty array it saves an empty string instead of a null.