### PR TITLE
Update EnumRule.php

### DIFF
--- a/src/Rules/EnumRule.php
+++ b/src/Rules/EnumRule.php
@@ -52,7 +52,6 @@ class EnumRule implements Rule
     public function message(): string
     {
         return Lang::get('enum::validation.enum', [
-            'attribute' => $this->attribute,
             'value' => $this->value,
             'enum' => $this->enum,
             'other' => implode(', ', $this->getDisplayableOtherValues()),


### PR DESCRIPTION
The 'attribute' should not be replaced. Laravel's behavior should be used.

For example： 
```php
public function rules()
    {
        return [
            'attachments.*.type' => [new EnumRule(AttachmentType::class)],
        ];
    }

public function attributes()
    {
        return [
            'attachments.*.type' => 'Attachment type',
        ];
    }
```
The error message:
Before
```
The attachments.0.type field is not a valid Rules\AttachmentType.
```

After 
```
The Attachment type field is not a valid Rules\AttachmentType.
```

And we can publish translation and change it
```
The :attribute is not valid.
```
will be
```
The Attachment type is not valid.
```
