### PR TITLE
Make Form Request Enum casting work with nested array data

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ class StatusFormRequest extends FormRequest
     {
         return [
             'status' => new EnumRule(StatusEnum::class),
+            'properties.level' => new EnumRule(LevelEnum::class),
         ];
     }
 
@@ -170,6 +171,7 @@ class StatusFormRequest extends FormRequest
     {
         return [
             'status' => StatusEnum::class,
+            'properties.level' => LevelEnum::class,
         ];
     }
 }

--- a/src/Http/EnumRequest.php
+++ b/src/Http/EnumRequest.php
@@ -70,7 +70,11 @@ final class EnumRequest
                     continue;
                 }
 
-                $this[$key] = $enumClass::make($this[$key]);
+                $input = $this->all();
+
+                Arr::set($input, $key, $enumClass::make($this[$key]));
+
+                $this->replace($input);
             }
         };
     }

--- a/tests/Http/EnumRequestTest.php
+++ b/tests/Http/EnumRequestTest.php
@@ -200,6 +200,26 @@ final class EnumRequestTest extends TestCase
         $this->assertTrue(StatusEnum::draft()->equals($request['status']));
     }
 
+    public function it_can_transform_general_request_array_parameters_to_enum()
+    {
+        $request = $this->createRequest([
+            'properties' => [
+                'status' => 'draft',
+            ]
+        ]);
+
+        $request->transformEnums([
+            'locale' => LocaleEnum::class,
+            'properties.status' => StatusEnum::class,
+        ]);
+
+        $this->assertInstanceOf(LocaleEnum::class, $request['locale']);
+        $this->assertTrue(LocaleEnum::en()->equals($request['locale']));
+
+        $this->assertInstanceOf(StatusEnum::class, $request['payload']['status']);
+        $this->assertTrue(StatusEnum::draft()->equals($request['payload']['status']));
+    }
+
     /** @test */
     public function it_ignores_rules_if_general_request__parameter_is_not_present()
     {


### PR DESCRIPTION
Hello :wave: 

When working wit nested properties in a Form Request with Enum casting, `laravel-enum` did not work as expected.

The following code sample would create a new `properties.status` request input, instead of casting the value of `status` inside the `properties` array.

```php
public function enums(): array
    {
        return [
            'properties.status' => StatusEnum::class,
        ];
    }
```

I'm not sure about the implementation to make it work, I probably missed a magic Laravel way to do it, let me know, and I will amend my PR.

Thank you. 

