### PR TITLE
add optional wirable support to enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,41 @@ The static `register()` method is only a little helper - you can for sure regist
 
 The faker methods itself are inherited from the base packages [Faker Provider](https://github.com/spatie/enum#faker-provider).
 
+### Livewire
+
+You can use an enum as a property on a Livewire component like this:
+
+```php
+class ShowCustomer extends Component
+{
+    public StatusEnum $statusEnum;
+
+    public function mount($id)
+    {
+        $customer = Customer::find($id);
+        $this->statusEnum = $customer->status;
+    }
+
+    public function render()
+    {
+        return view('livewire.customer');
+    }
+}
+```
+
+Just one thing is required to make this work: implement `\Livewire\Wireable` on all the enums you’ll be using with Livewire::
+
+```php
+use Livewire\Wireable;
+
+/**
+ * @method static self pending()
+ * @method static self active()
+ */
+final class StatusEnum implements Wireable
+{}
+```
+
 ## Testing
 
 ```bash

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -26,6 +26,16 @@ abstract class Enum extends BaseEnum implements Jsonable, Castable
         return new EnumRule(static::class);
     }
 
+    public static function fromLivewire($value): self
+    {
+        return self::from($value);
+    }
+
+    public function toLivewire(): mixed
+    {
+        return $this->value;
+    }
+
     public function toJson($options = 0): string
     {
         return json_encode($this->jsonSerialize(), $options);

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -26,14 +26,17 @@ abstract class Enum extends BaseEnum implements Jsonable, Castable
         return new EnumRule(static::class);
     }
 
-    public static function fromLivewire($value): self
+    public static function fromLivewire($enum): self
     {
-        return self::from($value);
+        return self::from($enum['value']);
     }
 
     public function toLivewire(): mixed
     {
-        return $this->value;
+        return [
+            'value' => $this->value,
+            'label' => $this->label,
+        ];
     }
 
     public function toJson($options = 0): string

--- a/src/Enum.php
+++ b/src/Enum.php
@@ -28,6 +28,10 @@ abstract class Enum extends BaseEnum implements Jsonable, Castable
 
     public static function fromLivewire($enum): self
     {
+        if (is_a($enum, self::class)) {
+            return $enum;
+        }
+
         return self::from($enum['value']);
     }
 

--- a/tests/WireableTest.php
+++ b/tests/WireableTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spatie\Enum\Laravel\Tests;
+
+use Spatie\Enum\Laravel\Tests\Extra\StatusEnum;
+
+final class WireableTest extends TestCase
+{
+    /** @test */
+    public function it_can_be_cast_to_livewire()
+    {
+        $enum = StatusEnum::draft();
+
+        $this->assertEquals('draft', $enum->toLivewire());
+    }
+
+    /** @test */
+    public function it_can_be_cast_for_livewire()
+    {
+        $this->assertTrue(
+            StatusEnum::fromLivewire('draft')->equals(StatusEnum::draft())
+        );
+    }
+}

--- a/tests/WireableTest.php
+++ b/tests/WireableTest.php
@@ -7,18 +7,12 @@ use Spatie\Enum\Laravel\Tests\Extra\StatusEnum;
 final class WireableTest extends TestCase
 {
     /** @test */
-    public function it_can_be_cast_to_livewire()
+    public function it_can_be_cast_to_and_from_livewire()
     {
         $enum = StatusEnum::draft();
 
-        $this->assertEquals('draft', $enum->toLivewire());
-    }
+        $castEnum = StatusEnum::fromLivewire($enum->toLivewire());
 
-    /** @test */
-    public function it_can_be_cast_for_livewire()
-    {
-        $this->assertTrue(
-            StatusEnum::fromLivewire('draft')->equals(StatusEnum::draft())
-        );
+        $this->assertTrue($castEnum->equals($enum));
     }
 }


### PR DESCRIPTION
This adds the methods `toLivewire()` and `fromLivewire()` on the base enum, but does not implement the `Wireable` trait as not all apps using this package will have Livewire.

It requires the end user to implement that interface on any enum(s) in their app they wish to use with Livewire.

Solution for #101 #102