### PR TITLE
Laravel 12 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,14 +19,19 @@ jobs:
                 include:
                     -   laravel: 8.*
                         testbench: ^6.23
+                        carbon: ^2.72.2
                     -   laravel: 9.*
                         testbench: 7.*
+                        carbon: ^2.72.2
                     -   laravel: 10.*
                         testbench: 8.*
+                        carbon: ^2.72.2
                     -   laravel: 11.*
                         testbench: 9.*
+                        carbon: ^2.72.2
                     -   laravel: 12.*
                         testbench: 10.*
+                        carbon: ^3.8.4
                 exclude:
                     -   laravel: 9.*
                         php: 7.4
@@ -77,7 +82,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.72.2" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:${{ matrix.carbon }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update --dev
                     composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
             -   name: Execute tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,8 +13,8 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ ubuntu-latest, windows-latest ]
-                php: [ 8.3, 8.2, 8.1, 8.0]
-                laravel: [ 8.*, 9.*, 10.*, 11.* ]
+                php: [ 8.4, 8.3, 8.2, 8.1, 8.0]
+                laravel: [ 8.*, 9.*, 10.*, 11.*, 12.* ]
                 stability: [ prefer-lowest, prefer-stable ]
                 include:
                     -   laravel: 8.*
@@ -25,6 +25,8 @@ jobs:
                         testbench: 8.*
                     -   laravel: 11.*
                         testbench: 9.*
+                    -   laravel: 12.*
+                        testbench: 10.*
                 exclude:
                     -   laravel: 9.*
                         php: 7.4
@@ -37,6 +39,8 @@ jobs:
                     -   laravel: 11.*
                         php: 8.0
                     -   laravel: 11.*
+                        php: 8.1
+                    -   laravel: 12.*
                         php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,6 +41,10 @@ jobs:
                     -   laravel: 11.*
                         php: 8.1
                     -   laravel: 12.*
+                        php: 7.4
+                    -   laravel: 12.*
+                        php: 8.0
+                    -   laravel: 12.*
                         php: 8.1
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "mockery/mockery": "^1.4.0",
         "orchestra/testbench": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
         "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0",
-        "vimeo/psalm": "^4.0 || ^5.0"
+        "vimeo/psalm": "^4.0 || ^5.0 || ^6.0"
     },
     "conflict": {
         "bensampo/laravel-enum": "*"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.4.0",
         "orchestra/testbench": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "phpunit/phpunit": "^9.5 || ^10.0",
+        "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0",
         "vimeo/psalm": "^4.0 || ^5.0"
     },
     "conflict": {

--- a/tests/Casts/EnumCastTest.php
+++ b/tests/Casts/EnumCastTest.php
@@ -48,7 +48,7 @@ final class EnumCastTest extends TestCase
         $cast->get(new Post(), 'key', null, []);
     }
 
-    public function provideEnumValueAccessorValues(): array
+    public static function provideEnumValueAccessorValues(): array
     {
         return [
             [null, null, ['nullable']],
@@ -58,7 +58,7 @@ final class EnumCastTest extends TestCase
         ];
     }
 
-    public function provideEnumValueMutatorValues(): array
+    public static function provideEnumValueMutatorValues(): array
     {
         return [
             [null, null, ['nullable']],

--- a/tests/Casts/EnumCollectionCastTest.php
+++ b/tests/Casts/EnumCollectionCastTest.php
@@ -52,7 +52,7 @@ final class EnumCollectionCastTest extends TestCase
         $cast->get(new Post(), 'key', null, []);
     }
 
-    public function provideEnumValueAccessorValues(): array
+    public static function provideEnumValueAccessorValues(): array
     {
         return [
             [null, null, ['nullable']],
@@ -64,7 +64,7 @@ final class EnumCollectionCastTest extends TestCase
         ];
     }
 
-    public function provideEnumValueMutatorValues(): array
+    public static function provideEnumValueMutatorValues(): array
     {
         return [
             [null, null, ['nullable']],

--- a/tests/Extra/StatusFormGetRequest.php
+++ b/tests/Extra/StatusFormGetRequest.php
@@ -6,7 +6,7 @@ use Spatie\Enum\Laravel\Http\EnumRequest;
 
 final class StatusFormGetRequest extends StatusFormRequest
 {
-    public function enums(): array
+    public function enums($key = null, $enumClass = null): array
     {
         return [
             EnumRequest::REQUEST_QUERY => [

--- a/tests/Extra/StatusFormPostRequest.php
+++ b/tests/Extra/StatusFormPostRequest.php
@@ -6,7 +6,7 @@ use Spatie\Enum\Laravel\Http\EnumRequest;
 
 final class StatusFormPostRequest extends StatusFormRequest
 {
-    public function enums(): array
+    public function enums($key = null, $enumClass = null): array
     {
         return [
             EnumRequest::REQUEST_REQUEST => [

--- a/tests/Extra/StatusFormRequest.php
+++ b/tests/Extra/StatusFormRequest.php
@@ -14,7 +14,7 @@ class StatusFormRequest extends FormRequest
         return [];
     }
 
-    public function enums(): array
+    public function enums($key = null, $enumClass = null): array
     {
         return [
             'status' => StatusEnum::class,

--- a/tests/Faker/FakerEnumProviderTest.php
+++ b/tests/Faker/FakerEnumProviderTest.php
@@ -66,7 +66,7 @@ final class FakerEnumProviderTest extends TestCase
         $this->assertTrue(in_array($label, array_values(StatusEnum::toArray()), true));
     }
 
-    public function repeatHundredTimes(): iterable
+    public static function repeatHundredTimes(): iterable
     {
         for ($i = 0; $i < 100; $i++) {
             yield [];

--- a/tests/Rules/EnumRuleTest.php
+++ b/tests/Rules/EnumRuleTest.php
@@ -162,7 +162,7 @@ final class EnumRuleTest extends TestCase
         $this->assertFalse($validator->validateEnum('attribute', 'stored draft', [StatusEnum::class], $validator));
     }
 
-    public function provideInvalidTypes(): array
+    public static function provideInvalidTypes(): array
     {
         return [
             'null' => [null],


### PR DESCRIPTION
Add support for Laravel 12

- Updates composer dependencies
- Updates workflow matrix for relevant versions
- Update PHPUnit `dataProvider` methods to be static (per https://github.com/sebastianbergmann/phpunit/commit/9caafe2d49b33a21f87db248a8ad6ca7c7bdac09)
- Make test `enums()` methods compatible with `Illuminate\Http\Request::class`

Closes  [#109](https://github.com/spatie/laravel-enum/issues/109)