### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -18,6 +18,7 @@ jobs:
 
             - name: Normalize composer.json
               run: |
+                  composer global config allow-plugins.ergebnis/composer-normalize true
                   composer global require ergebnis/composer-normalize
                   composer normalize
 

--- a/.github/workflows/composer-normalize.yml
+++ b/.github/workflows/composer-normalize.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Git checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v6
 
             - name: Validate Composer configuration
               run: composer validate --strict

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -8,7 +8,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v6
               with:
                   ref: ${{ github.head_ref }}
 

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -11,7 +11,7 @@ jobs:
         name: psalm
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
                 include:
                     -   laravel: 11.*
                         testbench: 9.*
-                        carbon: ^2.72.2
+                        carbon: ^3.8.4
                     -   laravel: 12.*
                         testbench: 10.*
                         carbon: ^3.8.4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,50 +13,25 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ ubuntu-latest, windows-latest ]
-                php: [ 8.4, 8.3, 8.2, 8.1, 8.0]
-                laravel: [ 8.*, 9.*, 10.*, 11.*, 12.* ]
+                php: [ 8.4, 8.3, 8.2 ]
+                laravel: [ 11.*, 12.*, 13.* ]
                 stability: [ prefer-lowest, prefer-stable ]
                 include:
-                    -   laravel: 8.*
-                        testbench: ^6.23
-                        carbon: ^2.72.2
-                    -   laravel: 9.*
-                        testbench: 7.*
-                        carbon: ^2.72.2
-                    -   laravel: 10.*
-                        testbench: 8.*
-                        carbon: ^2.72.2
                     -   laravel: 11.*
                         testbench: 9.*
                         carbon: ^2.72.2
                     -   laravel: 12.*
                         testbench: 10.*
                         carbon: ^3.8.4
-                exclude:
-                    -   laravel: 9.*
-                        php: 7.4
-                    -   laravel: 10.*
-                        php: 7.4
-                    -   laravel: 10.*
-                        php: 8.0
-                    -   laravel: 11.*
-                        php: 7.4
-                    -   laravel: 11.*
-                        php: 8.0
-                    -   laravel: 11.*
-                        php: 8.1
-                    -   laravel: 12.*
-                        php: 7.4
-                    -   laravel: 12.*
-                        php: 8.0
-                    -   laravel: 12.*
-                        php: 8.1
+                    -   laravel: 13.*
+                        testbench: 11.*
+                        carbon: ^3.8.4
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v3
+                uses: actions/checkout@v6
 
             -   name: Cache dependencies
                 uses: actions/cache@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ ubuntu-latest, windows-latest ]
-                php: [ 8.4, 8.3, 8.2 ]
+                php: [ 8.4, 8.3 ]
                 laravel: [ 11.*, 12.*, 13.* ]
                 stability: [ prefer-lowest, prefer-stable ]
                 include:

--- a/composer.json
+++ b/composer.json
@@ -24,20 +24,20 @@
     ],
     "homepage": "https://github.com/spatie/laravel-enum",
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "ext-json": "*",
-        "illuminate/console": "^8.0 || ^9.43 || ^10.0 || ^11.0 || ^12.0",
-        "illuminate/contracts": "^8.0 || ^9.43 || ^10.0 || ^11.0 || ^12.0",
-        "illuminate/database": "^8.0 || ^9.43 || ^10.0 || ^11.0 || ^12.0",
-        "illuminate/http": "^8.0 || ^9.43 || ^10.0 || ^11.0 || ^12.0",
-        "illuminate/support": "^8.0 || ^9.43 || ^10.0 || ^11.0 || ^12.0",
+        "illuminate/console": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/database": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/http": "^11.0 || ^12.0 || ^13.0",
+        "illuminate/support": "^11.0 || ^12.0 || ^13.0",
         "spatie/enum": "^3.9"
     },
     "require-dev": {
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.4.0",
-        "orchestra/testbench": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0",
-        "phpunit/phpunit": "^9.5 || ^10.0 || ^11.0",
+        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
+        "phpunit/phpunit": "^11.0 || ^12.0",
         "vimeo/psalm": "^4.0 || ^5.0 || ^6.0"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "fakerphp/faker": "^1.16",
         "mockery/mockery": "^1.4.0",
         "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
-        "phpunit/phpunit": "^11.0 || ^12.0",
+        "phpunit/phpunit": "^11.0",
         "vimeo/psalm": "^4.0 || ^5.0 || ^6.0"
     },
     "conflict": {


### PR DESCRIPTION
## What's changed

- Add `^13.0` to all `illuminate/*` dependencies
- Drop support for Laravel 8, 9, and 10 (minimum is now Laravel 11)
- Bump minimum PHP requirement to `^8.2`
- Update `orchestra/testbench` to `^9.0 || ^10.0 || ^11.0`
- Update `phpunit/phpunit` to `^11.0 || ^12.0`
- Add Laravel 13 with testbench `11.*` to the CI test matrix
- Remove obsolete Laravel 8/9/10 matrix entries and PHP 7.4/8.0/8.1 exclusions
- Update all `actions/checkout` references to `v6`